### PR TITLE
Fix loop and incompatible calls

### DIFF
--- a/Inventory/Bound-with-parts/delete_bound_with_parts_by_uuid.sh
+++ b/Inventory/Bound-with-parts/delete_bound_with_parts_by_uuid.sh
@@ -10,40 +10,36 @@ deletedRecordDir="log_deleted_bound_with_parts"
 output_file="${deletedRecordDir}/deleted_ids_${timestamp}.log"
 [ ! -d "$deletedRecordDir" ] && mkdir -p "$deletedRecordDir"
 
-# Fetching IDs
-echo "Fetching IDs..."
-offset=0
-limit=100
-total_records=1 # Run loop at least once until the exact number of records is known 
-id_list=()
+# Show record count
+response=$(curl -s -X GET -H "x-okapi-tenant: ${tenant}" -H "x-okapi-token: ${okapi_token}" "${okapi_url}/inventory-storage/bound-with-parts?limit=0")
+total_records=$(echo "$response" | jq -r '.totalRecords')
 
-while [ $offset -lt $total_records ]; do
-    response=$(curl -s -X GET -H "x-okapi-tenant: ${tenant}" -H "x-okapi-token: ${okapi_token}" "${okapi_url}/inventory-storage/bound-with-parts?limit=${limit}&offset=${offset}")
-    ids=$(echo "$response" | jq -r '.boundWithParts[].id')
-    id_list+=($ids)
-    current_count=$(echo "$ids" | wc -w)
-    total_records=$(echo "$response" | jq -r '.totalRecords')
-    offset=$((offset + limit))
-    echo "Processed $current_count from $offset of $total_records records"
-    #echo "Processed $offset / $total_records"
-done
-
-# Deleting IDs
-read -p "Are you sure you want to DELETE these instances? Type 'y' to proceed: " -n 1 -r
+# Confirm
+read -r -p "Are you sure you want to DELETE ${total_records} bound-with-parts? Type 'y' to proceed: " REPLY
 echo
-if [[ $REPLY =~ ^[Yy]$ ]]
+if [ "$REPLY" != "Y" -a "$REPLY" != "y" ]
 then
-    for id in "${id_list[@]}"; do
-        echo "Deleting ID: $id"
-        delete_result=$(curl -s -X DELETE -H "x-okapi-tenant: ${tenant}" -H "x-okapi-token: ${okapi_token}" "${okapi_url}/inventory-storage/bound-with-parts/${id}")
-        # Check if the deletion was successful and log the ID
-        if [[ "$delete_result" == *'204 No Content'* ]]; then
-            echo "$id" >> "$output_file"
-        else
-            echo "Failed to delete $id: $delete_result" >> "$output_file"
-        fi
-    done
-    echo "Deletion complete. See $output_file for details."
-else
     echo "Operation aborted."
+    exit 2
 fi
+
+# Fetch one record and delete it until no more found or failure
+while true; do
+    response=$(curl -s -X GET -H "x-okapi-tenant: ${tenant}" -H "x-okapi-token: ${okapi_token}" "${okapi_url}/inventory-storage/bound-with-parts?limit=1")
+    id=$(echo "$response" | jq -r '.boundWithParts[].id')
+    if [ -z "$id" ]; then
+        echo "Deletion complete. See $output_file for details."
+        break
+    fi
+    echo "Deleting ID: $id"
+    response=$(curl -D - -sS -X DELETE -H "x-okapi-tenant: ${tenant}" -H "x-okapi-token: ${okapi_token}" "${okapi_url}/inventory-storage/bound-with-parts/${id}")
+    # Check if the deletion was successful and log the ID
+    if echo "$response" | head -1 | grep -q " 204 "; then
+        echo "$id" >> "$output_file"
+    else
+        response="Failed to delete $id: $response"
+        echo "$response"
+        echo "$response" >> "$output_file"
+        exit 1
+    fi
+done


### PR DESCRIPTION
Avoid totalRecords:
https://github.com/folio-org/raml-module-builder?tab=readme-ov-file#estimated-totalrecords

Use a while loop instead.

To avoid a race condition if records are changed during the loop don't fetch all ids, fetch a single id only.

Avoid the non-standard '-n 1' read argument.

Avoid the non-standard '=~' operator.

Avoid the non-standard '[[' operator.